### PR TITLE
feat: make ghost sounds match character sounds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - run: cd Display_Config/Display_Config/src-tauri && cargo fmt --all --check
       - run: cd Display_Config/Display_Config/src-tauri && cargo clippy -- -Dwarnings
   displayConfigTestRust:
-    name: displayConfig:lintRust
+    name: displayConfig:testRust
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: cd Display_Config/Display_Config/src-tauri && cargo fmt --all --check
       - run: cd Display_Config/Display_Config/src-tauri && cargo clippy -- -Dwarnings
+  displayConfigTestRust:
+    name: displayConfig:lintRust
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: cd Display_Config/Display_Config/src-tauri && cargo test
   displayConfigLintVue:
     name: displayConfig:lintVue
     runs-on: windows-latest

--- a/Display_Config/Display_Config/components.d.ts
+++ b/Display_Config/Display_Config/components.d.ts
@@ -11,6 +11,7 @@ declare module 'vue' {
     EnableLoggingTooltip: typeof import('./src/components/EnableLoggingTooltip.vue')['default']
     ErrorDialog: typeof import('./src/components/ErrorDialog.vue')['default']
     FovSelectorRow: typeof import('./src/components/FovSelectorRow.vue')['default']
+    GhostSoundsTooltip: typeof import('./src/components/GhostSoundsTooltip.vue')['default']
     LanguageSelect: typeof import('./src/components/LanguageSelect.vue')['default']
     RenderDistanceRow: typeof import('./src/components/RenderDistanceRow.vue')['default']
     RenderOptions: typeof import('./src/components/RenderOptions.vue')['default']

--- a/Display_Config/Display_Config/components.d.ts
+++ b/Display_Config/Display_Config/components.d.ts
@@ -10,7 +10,9 @@ declare module 'vue' {
     Autostart: typeof import('./src/components/Autostart.vue')['default']
     EnableLoggingTooltip: typeof import('./src/components/EnableLoggingTooltip.vue')['default']
     ErrorDialog: typeof import('./src/components/ErrorDialog.vue')['default']
+    FovSelectorRow: typeof import('./src/components/FovSelectorRow.vue')['default']
     LanguageSelect: typeof import('./src/components/LanguageSelect.vue')['default']
+    RenderDistanceRow: typeof import('./src/components/RenderDistanceRow.vue')['default']
     RenderOptions: typeof import('./src/components/RenderOptions.vue')['default']
     TrainerOptions: typeof import('./src/components/TrainerOptions.vue')['default']
   }

--- a/Display_Config/Display_Config/package.json
+++ b/Display_Config/Display_Config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "display-config",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Display_Config/Display_Config/src-tauri/Cargo.lock
+++ b/Display_Config/Display_Config/src-tauri/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "display-config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "opener",
  "serde",

--- a/Display_Config/Display_Config/src-tauri/Cargo.lock
+++ b/Display_Config/Display_Config/src-tauri/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "async-broadcast"
@@ -123,7 +123,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -155,7 +155,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -167,7 +167,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -196,13 +196,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -275,18 +275,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -303,7 +297,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
+dependencies = [
+ "objc2 0.6.0",
 ]
 
 [[package]]
@@ -353,15 +356,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -371,9 +374,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -384,7 +387,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -423,33 +426,33 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cargo_toml"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
+checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
 dependencies = [
  "serde",
- "toml 0.8.19",
+ "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -495,45 +498,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
-dependencies = [
- "bitflags 2.8.0",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
-dependencies = [
- "bitflags 2.8.0",
- "block",
- "core-foundation",
- "core-graphics-types",
- "libc",
- "objc",
+ "windows-link",
 ]
 
 [[package]]
@@ -593,7 +566,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -606,16 +579,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "libc",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -634,25 +607,6 @@ name = "crossbeam-channel"
 version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -697,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -707,14 +661,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -722,27 +676,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -758,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -768,15 +722,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -791,23 +745,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -838,7 +792,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -861,7 +815,7 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -875,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dtoa-short"
@@ -896,26 +850,20 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "embed-resource"
-version = "2.5.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68b6f9f63a0b6a38bc447d4ce84e2b388f3ec95c99c641c8ff0dd3ef89a6379"
+checksum = "7fbc6e0d8e0c03a655b53ca813f0463d2c956bc4db8138dbc89f120b066551e3"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.8.19",
+ "toml",
  "vswhom",
  "winreg",
 ]
@@ -950,20 +898,20 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
  "typeid",
@@ -971,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -992,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1027,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1059,7 +1007,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1140,7 +1088,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1313,6 +1261,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,7 +1316,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1384,7 +1344,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1463,7 +1423,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1518,13 +1478,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.14",
+ "itoa 1.0.15",
 ]
 
 [[package]]
@@ -1539,12 +1499,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1552,15 +1512,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1568,7 +1528,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "itoa 1.0.14",
+ "itoa 1.0.15",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -1577,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1587,6 +1547,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1596,16 +1557,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -1619,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "ico"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3804960be0bb5e4edb1e1ad67afd321a9ecfd875c3e65c099468fd2717d7cae"
+checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
  "png",
@@ -1668,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -1692,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -1713,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -1742,7 +1704,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1785,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1796,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "infer"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
 ]
@@ -1836,9 +1798,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -1923,7 +1885,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -1973,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libdbus-sys"
@@ -2003,7 +1965,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -2014,10 +1976,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2031,24 +1999,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "markup5ever"
@@ -2093,9 +2052,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2114,21 +2073,22 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdae9c00e61cc0579bcac625e8ad22104c60548a025bfc972dc83868a28e1484"
+checksum = "4de14a9b5d569ca68d7c891d613b390cf5ab4f851c77aaa2f9e435555d3d9492"
 dependencies = [
  "crossbeam-channel",
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
  "once_cell",
  "png",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "windows-sys 0.59.0",
 ]
 
@@ -2138,7 +2098,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2174,7 +2134,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2235,19 +2195,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2255,9 +2206,6 @@ name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "objc2"
@@ -2270,79 +2218,86 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-app-kit"
-version = "0.2.2"
+name = "objc2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
+ "objc2-encode",
+ "objc2-exception-helper",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2 0.6.0",
  "libc",
- "objc2",
+ "objc2 0.6.0",
+ "objc2-cloud-kit",
  "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-core-image",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.0",
+ "objc2-quartz-core 0.3.0",
 ]
 
 [[package]]
 name = "objc2-cloud-kit"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
- "objc2-core-location",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-contacts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
-dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
 name = "objc2-core-data"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
 name = "objc2-core-image"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
-dependencies = [
- "block2",
- "objc2",
- "objc2-contacts",
- "objc2-foundation",
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
@@ -2352,27 +2307,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "objc2-exception-helper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "objc2-foundation"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
+ "bitflags 2.9.0",
+ "block2 0.5.1",
  "libc",
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
-name = "objc2-link-presentation"
-version = "0.2.2"
+name = "objc2-foundation"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
- "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "block2 0.6.0",
+ "libc",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2381,10 +2357,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2393,79 +2369,48 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
 [[package]]
-name = "objc2-symbols"
-version = "0.2.2"
+name = "objc2-quartz-core"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+checksum = "777a571be14a42a3990d4ebedaeb8b54cd17377ec21b92e8200ac03797b3bee1"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-foundation",
- "objc2-link-presentation",
- "objc2-quartz-core",
- "objc2-symbols",
- "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-uniform-type-identifiers"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
-dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
-dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
- "objc2-core-location",
- "objc2-foundation",
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
 name = "objc2-web-kit"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bc69301064cebefc6c4c90ce9cba69225239e4b8ff99d445a2b5563797da65"
+checksum = "b717127e4014b0f9f3e8bba3d3f2acec81f1bde01f656823036e823ed2c94dce"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "objc2",
+ "bitflags 2.9.0",
+ "block2 0.6.0",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
@@ -2479,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "open"
@@ -2693,7 +2638,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2748,18 +2693,18 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "quick-xml",
  "serde",
  "time",
@@ -2788,7 +2733,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2801,9 +2746,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -2835,11 +2780,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -2874,9 +2819,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -2892,12 +2837,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -2987,43 +2938,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3057,9 +2988,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3114,24 +3045,37 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3144,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
@@ -3159,14 +3103,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3197,27 +3141,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-untagged"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
 dependencies = [
  "erased-serde",
  "serde",
@@ -3226,13 +3170,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3243,16 +3187,16 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "itoa 1.0.14",
+ "itoa 1.0.15",
  "memchr",
  "ryu",
  "serde",
@@ -3260,13 +3204,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3285,7 +3229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.14",
+ "itoa 1.0.15",
  "ryu",
  "serde",
 ]
@@ -3300,7 +3244,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3317,7 +3261,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3407,15 +3351,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3433,9 +3377,9 @@ dependencies = [
  "foreign-types",
  "js-sys",
  "log",
- "objc2",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
  "raw-window-handle",
  "redox_syscall",
  "wasm-bindgen",
@@ -3483,26 +3427,25 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -3537,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3563,20 +3506,19 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
  "windows 0.57.0",
 ]
 
@@ -3589,18 +3531,17 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.19",
+ "toml",
  "version-compare",
 ]
 
 [[package]]
 name = "tao"
-version = "0.31.1"
+version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3731d04d4ac210cd5f344087733943b9bfb1a32654387dad4d1c70de21aee2c9"
+checksum = "63c8b1020610b9138dd7b1e06cf259ae91aa05c30f3bd0d6b42a03997b92dec1"
 dependencies = [
- "bitflags 2.8.0",
- "cocoa",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
@@ -3617,7 +3558,9 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc",
+ "objc2 0.6.0",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.0",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -3625,8 +3568,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.60.0",
+ "windows-core 0.60.1",
  "windows-version",
  "x11-dl",
 ]
@@ -3639,7 +3582,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3650,9 +3593,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.2.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f6efc261c7905839b4914889a5b25df07f0ff89c63fb4afd6ff8c96af15e4d"
+checksum = "4d08db1ff9e011e04014e737ec022610d756c0eae0b3b3a9037bccaf3003173a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3670,9 +3613,9 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.0",
  "percent-encoding",
  "plist",
  "raw-window-handle",
@@ -3687,7 +3630,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tray-icon",
  "url",
@@ -3695,14 +3638,14 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.58.0",
+ "windows 0.60.0",
 ]
 
 [[package]]
 name = "tauri-build"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e950124f6779c6cf98e3260c7a6c8488a74aa6350dd54c6950fdaa349bca2df"
+checksum = "0fd20e4661c2cce65343319e6e8da256958f5af958cafc47c0d0af66a55dcd17"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3716,15 +3659,15 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.8.19",
+ "toml",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77894f9ddb5cb6c04fcfe8c8869ebe0aded4dabf19917118d48be4a95599ab5"
+checksum = "458258b19032450ccf975840116ecf013e539eadbb74420bd890e8c56ab2b1a4"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3738,9 +3681,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tauri-utils",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "url",
  "uuid",
@@ -3749,23 +3692,23 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3240a5caed760a532e8f687be6f05b2c7d11a1d791fb53ccc08cfeb3e5308736"
+checksum = "d402813d3b9c773a0fa58697c457c771f10e735498fdcb7b343264d18e5a601f"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5841b9a0200e954ef7457f8d327091424328891e267a97b641dc246cc54d0dec"
+checksum = "a4190775d6ff73fe66d9af44c012739a2659720efd9c0e1e56a918678038699d"
 dependencies = [
  "anyhow",
  "glob",
@@ -3774,37 +3717,37 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "toml 0.8.19",
+ "toml",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-plugin-opener"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635ed7c580dc3cdc61c94097d38ef517d749ffc0141c806d904e68e4b0cf1c2a"
+checksum = "2fdc6cb608e04b7d2b6d1f21e9444ad49245f6d03465ba53323d692d1ceb1a30"
 dependencies = [
  "dunce",
  "glob",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.0",
  "open",
  "schemars",
  "serde",
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "url",
- "windows 0.58.0",
+ "windows 0.60.0",
  "zbus",
 ]
 
 [[package]]
 name = "tauri-plugin-process"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cc553ab29581c8c43dfa5fb0c9d5aee8ba962ad3b42908eea26c79610441b7"
+checksum = "57da5888533e802b6206b9685091f8714aa1f5266dc80051a82388449558b773"
 dependencies = [
  "tauri",
  "tauri-plugin",
@@ -3812,10 +3755,11 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.3.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2274ef891ccc0a8d318deffa9d70053f947664d12d58b9c0d1ae5e89237e01f7"
+checksum = "00ada7ac2f9276f09b8c3afffd3215fd5d9bff23c22df8a7c70e7ef67cacd532"
 dependencies = [
+ "cookie",
  "dpi",
  "gtk",
  "http",
@@ -3824,24 +3768,25 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "url",
- "windows 0.58.0",
+ "windows 0.60.0",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.3.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3707b40711d3b9f6519150869e358ffbde7c57567fb9b5a8b51150606939b2a0"
+checksum = "cf2e5842c57e154af43a20a49c7efee0ce2578c20b4c2bdf266852b422d2e421"
 dependencies = [
  "gtk",
  "http",
  "jni",
  "log",
- "objc2",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.0",
+ "once_cell",
  "percent-encoding",
  "raw-window-handle",
  "softbuffer",
@@ -3851,16 +3796,17 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.58.0",
+ "windows 0.60.0",
  "wry",
 ]
 
 [[package]]
 name = "tauri-utils"
-version = "2.1.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb10e7cc97456b2d5b9c03e335b5de5da982039a303a20d10006885e4523a0"
+checksum = "1f037e66c7638cc0a2213f61566932b9a06882b8346486579c90e4b019bac447"
 dependencies = [
+ "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
@@ -3884,8 +3830,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.11",
- "toml 0.8.19",
+ "thiserror 2.0.12",
+ "toml",
  "url",
  "urlpattern",
  "uuid",
@@ -3894,25 +3840,24 @@ dependencies = [
 
 [[package]]
 name = "tauri-winres"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5993dc129e544393574288923d1ec447c857f3f644187f4fbf7d9a875fbfc4fb"
+checksum = "56eaa45f707bedf34d19312c26d350bc0f3c59a47e58e8adbeecdc850d2c13a0"
 dependencies = [
  "embed-resource",
- "toml 0.7.8",
+ "toml",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -3944,11 +3889,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3959,28 +3904,28 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
- "itoa 1.0.14",
+ "itoa 1.0.15",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3990,15 +3935,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4016,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4031,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4044,26 +3989,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -4081,9 +4014,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.7.1",
- "serde",
- "serde_spanned",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4094,22 +4025,22 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.24",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -4158,7 +4089,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4172,22 +4103,23 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48a05076dd272615d03033bf04f480199f7d1b66a8ac64d75c625fc4a70c06b"
+checksum = "d433764348e7084bad2c5ea22c96c71b61b17afe3a11645710f533bd72b6a2b5"
 dependencies = [
- "core-graphics",
  "crossbeam-channel",
  "dirs",
  "libappindicator",
  "muda",
- "objc2",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.0",
  "once_cell",
  "png",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "windows-sys 0.59.0",
 ]
 
@@ -4199,15 +4131,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typeid"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uds_windows"
@@ -4263,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4317,11 +4249,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "serde",
 ]
 
@@ -4349,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "vswhom-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18"
+checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
@@ -4389,6 +4321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,7 +4351,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -4445,7 +4386,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4528,16 +4469,16 @@ dependencies = [
 
 [[package]]
 name = "webview2-com"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823e7ebcfaea51e78f72c87fc3b65a1e602c321f407a0b36dbb327d7bb7cd921"
+checksum = "b0d606f600e5272b514dbb66539dd068211cc20155be8d3958201b4b5bd79ed3"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.58.0",
- "windows-core 0.58.0",
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
+ "windows 0.60.0",
+ "windows-core 0.60.1",
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.1",
 ]
 
 [[package]]
@@ -4548,18 +4489,18 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "webview2-com-sys"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a82bce72db6e5ee83c68b5de1e2cd6ea195b9fbff91cb37df5884cbe3222df4"
+checksum = "bfb27fccd3c27f68e9a6af1bcf48c2d82534b8675b83608a4d81446d095a17ac"
 dependencies = [
- "thiserror 1.0.69",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "thiserror 2.0.12",
+ "windows 0.60.0",
+ "windows-core 0.60.1",
 ]
 
 [[package]]
@@ -4595,13 +4536,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "window-vibrancy"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea403deff7b51fff19e261330f71608ff2cdef5721d72b64180bb95be7c4150"
+checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -4619,21 +4561,24 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.60.1",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-collections"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.60.1",
 ]
 
 [[package]]
@@ -4650,15 +4595,38 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
+dependencies = [
+ "windows-core 0.60.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4669,18 +4637,29 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4691,29 +4670,45 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
+dependencies = [
+ "windows-core 0.60.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -4727,21 +4722,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4844,11 +4847,11 @@ dependencies = [
 
 [[package]]
 name = "windows-version"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12476c23a74725c539b24eae8bfc0dac4029c39cdb561d9f23616accd4ae26d"
+checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
 dependencies = [
- "windows-targets 0.53.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -5042,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -5057,6 +5060,15 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5073,12 +5085,12 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.48.1"
+version = "0.50.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e33c08b174442ff80d5c791020696f9f8b4e4a87b8cfc7494aad6167ec44e1"
+checksum = "b19b78efae8b853c6c817e8752fc1dbf9cab8a8ffe9c30f399bd750ccf0f0730"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.0",
  "cookie",
  "crossbeam-channel",
  "dpi",
@@ -5092,9 +5104,10 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc2",
+ "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -5103,13 +5116,13 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.60.0",
+ "windows-core 0.60.1",
  "windows-version",
  "x11-dl",
 ]
@@ -5165,15 +5178,15 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.3.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2494e4b3f44d8363eef79a8a75fc0649efb710eef65a66b5e688a5eb4afe678a"
+checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5188,7 +5201,7 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-util",
+ "futures-lite",
  "hex",
  "nix",
  "ordered-stream",
@@ -5198,7 +5211,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
- "winnow 0.6.24",
+ "winnow 0.7.4",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -5207,14 +5220,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.3.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445efc01929302aee95e2b25bbb62a301ea8a6369466e4278e58e7d1dfb23631"
+checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -5222,55 +5235,54 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519629a3f80976d89c575895b05677cbc45eaf9f70d62a364d819ba646409cc8"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow 0.6.24",
+ "winnow 0.7.4",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5293,47 +5305,47 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zvariant"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
+checksum = "b2df9ee044893fcffbdc25de30546edef3e32341466811ca18421e3cd6c5a3ac"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "static_assertions",
- "winnow 0.6.24",
+ "winnow 0.7.4",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
+checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.96",
- "winnow 0.6.24",
+ "syn 2.0.100",
+ "winnow 0.7.4",
 ]

--- a/Display_Config/Display_Config/src-tauri/Cargo.toml
+++ b/Display_Config/Display_Config/src-tauri/Cargo.toml
@@ -24,4 +24,4 @@ tauri-plugin-process = "2.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 opener = "0.7.2"
-sysinfo = "0.33.1"
+sysinfo = "0.34.2"

--- a/Display_Config/Display_Config/src-tauri/Cargo.toml
+++ b/Display_Config/Display_Config/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "display-config"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/Display_Config/Display_Config/src-tauri/src/config_parser.rs
+++ b/Display_Config/Display_Config/src-tauri/src/config_parser.rs
@@ -1,0 +1,174 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigEntry {
+    pub entry_type: String,
+    pub entries: Vec<(String, String)>,
+}
+
+pub fn parse_config<P: AsRef<Path>>(path: P) -> io::Result<Vec<ConfigEntry>> {
+    let content = fs::read_to_string(path)?;
+    parse_config_str(&content)
+}
+pub fn parse_config_str(content: &str) -> io::Result<Vec<ConfigEntry>> {
+    let mut result = Vec::new();
+    let mut lines = content.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Extract entry type
+        let entry_type = if line.ends_with('{') {
+            line.trim_end_matches('{').trim().to_string()
+        } else {
+            // peek next non-empty line for '{'
+            let entry_type = line.to_string();
+            loop {
+                match lines.peek() {
+                    Some(next_line) if next_line.trim().is_empty() => {
+                        lines.next();
+                        continue;
+                    }
+                    Some(next_line) if next_line.trim() == "{" => {
+                        lines.next();
+                        break;
+                    }
+                    Some(unexpected_line) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Expected '{{', but found '{}'", unexpected_line.trim()),
+                        ));
+                    }
+                    None => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "Unexpected end of file while looking for '{'",
+                        ));
+                    }
+                }
+            }
+            entry_type
+        };
+
+        let mut entries = Vec::new();
+
+        for line in lines.by_ref() {
+            let line = line.trim();
+
+            if line.starts_with('}') {
+                break;
+            }
+
+            if line.is_empty() || !line.contains('=') {
+                continue;
+            }
+
+            let parts: Vec<&str> = line.split('=').collect();
+            if parts.len() >= 2 {
+                let key = parts[0].trim().to_string();
+
+                let joined_value = parts[1..].join("=");
+                let value_part = joined_value.trim();
+                let value = if let Some(stripped) = value_part.strip_suffix(';') {
+                    stripped.trim()
+                } else {
+                    value_part
+                };
+
+                let value = value.to_string();
+                entries.push((key, value));
+            }
+        }
+
+        result.push(ConfigEntry {
+            entry_type,
+            entries,
+        });
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_config() {
+        let test_data = r#"
+            player
+            {
+                bone_config_file = "data/characters/plrbnecnf_2.txt";
+                mesh_config_file = "data/characters/keith/plrmshcnf.txt";
+            };
+    
+            player
+            {
+                bone_config_file = "data/characters/plrbnecnf_1.txt";
+                mesh_config_file = "data/characters/akiko/plrmshcnf.txt";
+            };"#;
+
+        let config: Vec<ConfigEntry> = parse_config_str(test_data).unwrap();
+
+        assert_eq!(config.len(), 2);
+
+        assert_eq!(config[0].entry_type, "player");
+        assert_eq!(
+            config[0].entries[0],
+            (
+                "bone_config_file".to_string(),
+                "\"data/characters/plrbnecnf_2.txt\"".to_string()
+            )
+        );
+        assert_eq!(
+            config[0].entries[1],
+            (
+                "mesh_config_file".to_string(),
+                "\"data/characters/keith/plrmshcnf.txt\"".to_string()
+            )
+        );
+
+        assert_eq!(config[1].entry_type, "player");
+        assert_eq!(
+            config[1].entries[0],
+            (
+                "bone_config_file".to_string(),
+                "\"data/characters/plrbnecnf_1.txt\"".to_string()
+            )
+        );
+        assert_eq!(
+            config[1].entries[1],
+            (
+                "mesh_config_file".to_string(),
+                "\"data/characters/akiko/plrmshcnf.txt\"".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_config_returns_error() {
+        let test_data = r#"
+        player
+{
+	bone_config_file 	= "data/characters/plrbnecnf_2.txt";
+	mesh_config_file 	= "data/characters/bulk_30/plrmshcnf.txt";
+	player_config_file 	= "data/characters/bulk_30/plrcnf.txt";
+};
+	player_config_file 	= "data/characters/bulk_29/plrcnf.txt";
+};
+
+player
+{
+	bone_config_file 	= "data/characters/plrbnecnf_2.txt";
+	mesh_config_file 	= "data/characters/bulk_30/plrmshcnf.txt";
+	player_config_file 	= "data/characters/bulk_30/plrcnf.txt";
+};"#;
+        let config = parse_config_str(test_data);
+        assert!(config.is_err(), "Expected error, but got: {:?}", config);
+    }
+}

--- a/Display_Config/Display_Config/src-tauri/src/config_writer.rs
+++ b/Display_Config/Display_Config/src-tauri/src/config_writer.rs
@@ -1,0 +1,75 @@
+use crate::config_parser::ConfigEntry;
+use std::io::Write;
+use std::{fs, io, path::PathBuf};
+
+pub fn write_config_to_file(path: PathBuf, entries: &[ConfigEntry]) -> io::Result<()> {
+    let file = fs::File::create(path)?;
+    write_config(file, entries)
+}
+
+pub fn write_config<W: Write>(mut writer: W, entries: &[ConfigEntry]) -> io::Result<()> {
+    for (index, entry) in entries.iter().enumerate() {
+        writeln!(writer, "{}", entry.entry_type)?;
+        writeln!(writer, "{{")?;
+        for (key, value) in &entry.entries {
+            writeln!(writer, "\t{} \t= {};", key, value)?;
+        }
+
+        write!(writer, "}};")?;
+        if index < entries.len() - 1 {
+            writeln!(writer, "\n")?; // Add a newline between entries
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config_parser::parse_config_str;
+
+    use super::*;
+    #[test]
+    pub fn test_write() {
+        let test_data = r#"player
+{
+	bone_config_file 	= "data/characters/plrbnecnf_2.txt";
+	mesh_config_file 	= "data/characters/keith/plrmshcnf.txt";
+};
+
+player
+{
+	bone_config_file 	= "data/characters/plrbnecnf_1.txt";
+	mesh_config_file 	= "data/characters/akiko/plrmshcnf.txt";
+};"#;
+
+        let config = parse_config_str(test_data).unwrap();
+        let mut buffer = Vec::new();
+        write_config(&mut buffer, &config).unwrap();
+
+        let output = String::from_utf8(buffer).unwrap();
+        assert_eq!(output, test_data);
+    }
+
+    #[test]
+    pub fn test_write_with_spaces() {
+        let test_data = r#"player
+{
+	bone_config_file 	= "data/characters/plrbnecnf_2.txt";
+	mesh_config_file 	= "data/characters/keith/plrmshcnf.txt";
+};
+
+player
+{
+	bone_config_file 	= "data/characters/plrbnecnf_1.txt";
+	mesh_config_file 	= "data/characters/akiko/plrmshcnf.txt";
+};"#;
+
+        let config = parse_config_str(test_data).unwrap();
+        let mut buffer = Vec::new();
+        write_config(&mut buffer, &config).unwrap();
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        assert_eq!(output, test_data);
+    }
+}

--- a/Display_Config/Display_Config/src-tauri/src/detail_config.rs
+++ b/Display_Config/Display_Config/src-tauri/src/detail_config.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+use crate::path_util::get_supreme_folder;
+
+#[tauri::command]
+pub fn write_detail_config(detail_config: DetailConfig) -> Result<(), String> {
+    let rd_config = get_supreme_folder().join("Data").join("Detail_Config.txt");
+
+    let content = fs::read_to_string(&rd_config)
+        .map_err(|e| format!("Failed to read {rd_config:?}: {}", e))?;
+
+    let mut lines: Vec<String> = content.lines().map(String::from).collect();
+    let configs = [
+        (
+            "visibility_cube_width",
+            detail_config.render_distance.to_string(),
+        ),
+        ("ground_detail", detail_config.ground_detail.to_string()),
+    ];
+
+    let mut found = vec![false; configs.len()];
+
+    // Update existing settings
+    for line_idx in 0..lines.len() {
+        for (config_idx, (key, value)) in configs.iter().enumerate() {
+            if lines[line_idx].starts_with(key) {
+                lines[line_idx] = format!("{}\t= {};", key, value);
+                found[config_idx] = true;
+                break;
+            }
+        }
+    }
+
+    // Append missing settings
+    for (config_idx, (key, value)) in configs.iter().enumerate() {
+        if !found[config_idx] {
+            lines.push(format!("{}\t= {};", key, value));
+        }
+    }
+
+    fs::write(&rd_config, lines.join("\n"))
+        .map_err(|e| format!("Failed to write config file: {}", e))?;
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetailConfig {
+    pub render_distance: i32,
+    pub ground_detail: i32,
+}

--- a/Display_Config/Display_Config/src-tauri/src/detail_config.rs
+++ b/Display_Config/Display_Config/src-tauri/src/detail_config.rs
@@ -23,10 +23,10 @@ pub fn write_detail_config(detail_config: DetailConfig) -> Result<(), String> {
     let mut found = vec![false; configs.len()];
 
     // Update existing settings
-    for line_idx in 0..lines.len() {
+    for line in &mut lines {
         for (config_idx, (key, value)) in configs.iter().enumerate() {
-            if lines[line_idx].starts_with(key) {
-                lines[line_idx] = format!("{}\t= {};", key, value);
+            if line.starts_with(key) {
+                *line = format!("{}\t= {};", key, value);
                 found[config_idx] = true;
                 break;
             }

--- a/Display_Config/Display_Config/src-tauri/src/file_commands.rs
+++ b/Display_Config/Display_Config/src-tauri/src/file_commands.rs
@@ -1,4 +1,4 @@
-use crate::path_util::get_supreme_folder;
+use crate::{path_util::get_supreme_folder, player_types::get_player_types_path};
 
 #[tauri::command]
 pub fn open_log_file() -> Result<(), String> {
@@ -8,4 +8,14 @@ pub fn open_log_file() -> Result<(), String> {
         return Ok(());
     }
     Err(format!("Log file not found {log_file:?}"))
+}
+
+#[tauri::command]
+pub fn open_player_types() -> Result<(), String> {
+    let player_types_file = get_player_types_path();
+    if player_types_file.exists() {
+        opener::open(player_types_file).map_err(|err| format!("Failed to open log file: {err}"))?;
+        return Ok(());
+    }
+    Err(format!("Player types file not found {player_types_file:?}"))
 }

--- a/Display_Config/Display_Config/src-tauri/src/inject.rs
+++ b/Display_Config/Display_Config/src-tauri/src/inject.rs
@@ -13,6 +13,7 @@ pub struct TrainerSettings {
     pub fov_height: Option<i32>,
     pub enable_logging: bool,
     pub make_ghosts_opaque: bool,
+    pub match_ghost_sounds_to_character: bool,
 }
 
 #[tauri::command]

--- a/Display_Config/Display_Config/src-tauri/src/lib.rs
+++ b/Display_Config/Display_Config/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ pub fn run() {
             get_log_data::get_log_data,
             language::write_language,
             detail_config::write_detail_config,
+            detail_config::read_detail_config,
             kill_exit_1
         ])
         .setup(|app| {

--- a/Display_Config/Display_Config/src-tauri/src/lib.rs
+++ b/Display_Config/Display_Config/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use tauri::Manager;
 
 mod close_others;
+mod detail_config;
 mod file_commands;
 mod get_log_data;
 mod inject;
@@ -34,6 +35,7 @@ pub fn run() {
             close_others::close_others,
             get_log_data::get_log_data,
             language::write_language,
+            detail_config::write_detail_config,
             kill_exit_1
         ])
         .setup(|app| {

--- a/Display_Config/Display_Config/src-tauri/src/lib.rs
+++ b/Display_Config/Display_Config/src-tauri/src/lib.rs
@@ -1,12 +1,15 @@
 use tauri::Manager;
 
 mod close_others;
+mod config_parser;
+mod config_writer;
 mod detail_config;
 mod file_commands;
 mod get_log_data;
 mod inject;
 mod language;
 mod path_util;
+mod player_types;
 mod rd_config;
 
 // fixme: is this really needed?
@@ -32,11 +35,14 @@ pub fn run() {
             rd_config::read_rd_config,
             rd_config::write_rd_config,
             file_commands::open_log_file,
+            file_commands::open_player_types,
             close_others::close_others,
             get_log_data::get_log_data,
             language::write_language,
             detail_config::write_detail_config,
             detail_config::read_detail_config,
+            player_types::set_first_player_type,
+            player_types::get_first_player_type,
             kill_exit_1
         ])
         .setup(|app| {

--- a/Display_Config/Display_Config/src-tauri/src/path_util.rs
+++ b/Display_Config/Display_Config/src-tauri/src/path_util.rs
@@ -9,6 +9,6 @@ pub fn get_supreme_folder() -> PathBuf {
     if exe_dir.join("Supreme_Game.dll").exists() {
         exe_dir
     } else {
-        PathBuf::from(r"C:\Games\Supreme")
+        PathBuf::from(r"C:\Games\Supreme2")
     }
 }

--- a/Display_Config/Display_Config/src-tauri/src/player_types.rs
+++ b/Display_Config/Display_Config/src-tauri/src/player_types.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use crate::{
+    config_parser::{parse_config, ConfigEntry},
+    config_writer::write_config_to_file,
+    path_util::get_supreme_folder,
+};
+
+#[tauri::command]
+pub fn set_first_player_type(character: String) -> Result<(), String> {
+    let character = character.trim().to_lowercase();
+    if get_first_player_type()? == character {
+        return Ok(());
+    }
+
+    let mut config = parse_config(get_player_types_path()).map_err(|e| e.to_string())?;
+    let idx = config
+        .iter()
+        .position(|x| {
+            get_character_name(x)
+                .map(|s| s == character)
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| format!("Character {character} not found"))?;
+
+    let entry = config.remove(idx);
+    config.insert(0, entry);
+
+    write_config_to_file(get_player_types_path(), &config)
+        .map_err(|e| format!("Failed to write player types: {e}"))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_first_player_type() -> Result<String, String> {
+    // return Ok("HEY!".to_string());
+    let config: Vec<ConfigEntry> =
+        parse_config(get_player_types_path()).map_err(|e| e.to_string())?;
+    get_character_name(&config[0])
+}
+
+fn get_character_name(entry: &ConfigEntry) -> Result<String, String> {
+    let mesh_value = entry
+        .entries
+        .iter()
+        .find(|x| x.0 == "mesh_config_file")
+        .map(|x| x.1.clone())
+        .ok_or_else(|| "mesh_config_file not found".to_string())?;
+
+    // pattern: data/characters/vincent/plrmshcnf.txt
+    // extract the character name "vincent"
+    mesh_value
+        .replace("\"", "")
+        .split("data/characters/")
+        .nth(1)
+        .ok_or_else(|| format!("{} needs to start with data/characters", mesh_value).to_string())?
+        .split('/')
+        .next()
+        .ok_or_else(|| "Invalid path format".to_string())
+        .map(|s| s.to_string())
+}
+
+pub fn get_player_types_path() -> PathBuf {
+    get_supreme_folder()
+        .join("Data")
+        .join("Characters")
+        .join("player_types.txt")
+}

--- a/Display_Config/Display_Config/src-tauri/src/rd_config.rs
+++ b/Display_Config/Display_Config/src-tauri/src/rd_config.rs
@@ -64,18 +64,18 @@ pub fn read_rd_config() -> String {
 }
 
 #[tauri::command]
-pub fn write_rd_config(config: RdConfig) -> Result<(), String> {
-    let rd_config = get_supreme_folder().join("rd_config.txt");
-    let mut file = File::create(&rd_config)
-        .map_err(|e| format!("Failed to create config file: {rd_config:?} {}", e))?;
+pub fn write_rd_config(rd_config: RdConfig) -> Result<(), String> {
+    let rd_config_path = get_supreme_folder().join("rd_config.txt");
+    let mut file = File::create(&rd_config_path)
+        .map_err(|e| format!("Failed to create config file: {rd_config_path:?} {}", e))?;
 
     let configs = [
-        format!("api_name = \"{}\";", config.api_name),
-        format!("width = {};", config.width),
-        format!("height = {};", config.height),
-        format!("depth = {};", config.depth),
-        format!("card_id = {};", config.card_id),
-        format!("fullscreen = {};", if config.fullscreen { 1 } else { 0 }),
+        format!("api_name = \"{}\";", rd_config.api_name),
+        format!("width = {};", rd_config.width),
+        format!("height = {};", rd_config.height),
+        format!("depth = {};", rd_config.depth),
+        format!("card_id = {};", rd_config.card_id),
+        format!("fullscreen = {};", if rd_config.fullscreen { 1 } else { 0 }),
     ];
 
     configs

--- a/Display_Config/Display_Config/src-tauri/tauri.conf.json
+++ b/Display_Config/Display_Config/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "display-config",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.display-config.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/Display_Config/Display_Config/src-tauri/tauri.conf.json
+++ b/Display_Config/Display_Config/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
         "label": "main",
         "visible": false,
         "width": 400,
-        "height": 620
+        "height": 660
       }
     ],
     "security": {

--- a/Display_Config/Display_Config/src/components/FovSelectorRow.vue
+++ b/Display_Config/Display_Config/src/components/FovSelectorRow.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="d-flex align-items-center ga-1">
+    <v-select
+      label="FOV Option"
+      :items="fovTypes"
+      style="flex-basis: 125px; flex-shrink: 0"
+      v-model="trainerSettings.fovType"
+    />
+    <v-text-field
+      type="number"
+      v-model="trainerSettings.fovWidth"
+      :disabled="formIsLoading || trainerSettings.fovType !== 'Custom'"
+      :rules="[(v: number) => validateNumber(v)]"
+      label="Width"
+      density="compact"
+    />
+    <v-text-field
+      type="number"
+      v-model="trainerSettings.fovHeight"
+      :disabled="formIsLoading || trainerSettings.fovType !== 'Custom'"
+      :rules="[(v: number) => validateNumber(v)]"
+      label="Height"
+    />
+    <div
+      class="align-self-center ml-1"
+      style="flex-basis: 37px; text-align: center; flex-shrink: 0"
+    >
+      <p>{{ getFovFactor() }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+import { useTrainerUISettingsStore } from "@/stores/trainerSettings";
+import type { FovType } from "../services/fovOptions";
+import { watch } from "vue";
+import { useRenderSettingsStore } from "@/stores/renderSettings";
+const { trainerSettings } = useTrainerUISettingsStore();
+const { renderSettings } = useRenderSettingsStore();
+const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
+
+const fovTypes: Array<FovType> = [
+  "MatchRes",
+  "Original",
+  "Custom",
+];
+
+fixBasedOnResolution(renderSettings.resolution);
+watch(() => trainerSettings.fovType, (newValue) => {
+  fixBasedOnResolution(renderSettings.resolution);
+  if (newValue === "Original") {
+    trainerSettings.fovWidth = 800;
+    trainerSettings.fovHeight = 600;
+  }
+});
+
+watch(() => renderSettings.resolution, (newValue) => fixBasedOnResolution(newValue));
+
+function fixBasedOnResolution(resolution: string | undefined) {
+    if (trainerSettings.fovType !== "MatchRes") return;
+    if (!resolution) return;
+    const spl = resolution.split("x");
+    if (spl.length !== 2) return;
+    const [width, height] = spl.map(Number);
+    trainerSettings.fovWidth = width;
+    trainerSettings.fovHeight = height;
+}
+
+function getFovFactor() {
+  if (!trainerSettings.fovWidth || !trainerSettings.fovHeight) {
+    return undefined;
+  }
+  return (
+    trainerSettings.fovWidth /
+    trainerSettings.fovHeight /
+    (4 / 3)
+  ).toFixed(2);
+}
+
+function validateNumber(v: number | undefined) {
+  if (v === undefined) {
+    return "required";
+  }
+  if (isNaN(v)) {
+    return "invalid number";
+  }
+  if (v <= 0) {
+    return "must be greater than 0";
+  }
+  return true;
+}
+
+</script>

--- a/Display_Config/Display_Config/src/components/GhostSoundsTooltip.vue
+++ b/Display_Config/Display_Config/src/components/GhostSoundsTooltip.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-tooltip
+    text="The default ghost sounds are mike. Enabling this will make them use speech_cfg.txt for the ghost player (first entry of player_types.txt) or guide."
+    location="bottom"
+  >
+    <template v-slot:activator="{ props }">
+      <v-icon
+        @click="openPlayerTypes"
+        icon="mdi-information"
+        class="text-medium-emphasis"
+        v-bind="props"
+      ></v-icon>
+    </template>
+  </v-tooltip>
+</template>
+
+<script lang="ts" setup>
+import { invoke } from '@tauri-apps/api/core';
+
+
+function openPlayerTypes() {
+  invoke('open_player_types');
+}
+</script>

--- a/Display_Config/Display_Config/src/components/LanguageSelect.vue
+++ b/Display_Config/Display_Config/src/components/LanguageSelect.vue
@@ -35,7 +35,7 @@ const { renderSettings } = useRenderSettingsStore();
 const countries = [
   { name: "English", code: "en", flag: "gb" },
   { name: "Finnish", code: "fi", flag: "fi" },
-  { name: "Italian", code: "it", flag: "it" },
+  // { name: "Italian", code: "it", flag: "it" },
   { name: "French", code: "fr", flag: "fr" },
   { name: "German", code: "de", flag: "de" },
 ];

--- a/Display_Config/Display_Config/src/components/RenderDistanceRow.vue
+++ b/Display_Config/Display_Config/src/components/RenderDistanceRow.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="d-flex ga-2">
-    <v-select style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;" label="Render Distance"
+    <v-select style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;" label="Render Distance (m)"
       :items="renderDistanceOptions" v-model="renderDistanceSelection" />
-    <v-text-field type="number" :disabled="formIsLoading || renderDistanceSelection !== 'Custom'" :rules="[(v: number) => (v && v > 0) || 'required']"
+    <v-text-field type="number" :rules="[(v: number) => (v && v > 0) || 'required']"
       label="Distance (m)" v-model="renderSettings.renderDistance" />
   </div>
 </template>
@@ -11,11 +11,12 @@
 import { useRenderSettingsStore } from "@/stores/renderSettings";
 import { ref, watch } from "vue";
 
-const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
+// const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
 const { renderSettings } = useRenderSettingsStore();
 
 const renderDistanceSelection = ref("Custom");
 const renderDistanceOptions = ['200m (Near)', '300m (Normal)', '450m (Far)', 'Custom'];
+updateBasedOnRenderDistance();
 
 watch(() => renderDistanceSelection.value, (newValue) => {
   if (newValue === "Custom") {
@@ -27,5 +28,20 @@ watch(() => renderDistanceSelection.value, (newValue) => {
     renderSettings.renderDistance = 450;
   }
 });
+
+watch(() => renderSettings.renderDistance, updateBasedOnRenderDistance);
+
+function updateBasedOnRenderDistance() {
+  const v = parseInt(renderSettings.renderDistance as unknown as string, 10);
+  if (v === 200) {
+    renderDistanceSelection.value = "200m (Near)";
+  } else if (v === 300) {
+    renderDistanceSelection.value = "300m (Normal)";
+  } else if (v === 450) {
+    renderDistanceSelection.value = "450m (Far)";
+  } else {
+    renderDistanceSelection.value = "Custom";
+  }
+}
 
 </script>

--- a/Display_Config/Display_Config/src/components/RenderDistanceRow.vue
+++ b/Display_Config/Display_Config/src/components/RenderDistanceRow.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="d-flex ga-2">
+    <v-select style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;" label="Render Distance"
+      :items="renderDistanceOptions" v-model="renderDistanceSelection" />
+    <v-text-field type="number" :disabled="formIsLoading || renderDistanceSelection !== 'Custom'" :rules="[(v: number) => (v && v > 0) || 'required']"
+      label="Distance (m)" v-model="renderSettings.renderDistance" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRenderSettingsStore } from "@/stores/renderSettings";
+import { ref, watch } from "vue";
+
+const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
+const { renderSettings } = useRenderSettingsStore();
+
+const renderDistanceSelection = ref("Custom");
+const renderDistanceOptions = ['200m (Near)', '300m (Normal)', '450m (Far)', 'Custom'];
+
+watch(() => renderDistanceSelection.value, (newValue) => {
+  if (newValue === "Custom") {
+  } else if (newValue === "200m (Near)") {
+    renderSettings.renderDistance = 200;
+  } else if (newValue === "300m (Normal)") {
+    renderSettings.renderDistance = 300;
+  } else if (newValue === "450m (Far)") {
+    renderSettings.renderDistance = 450;
+  }
+});
+
+</script>

--- a/Display_Config/Display_Config/src/components/RenderOptions.vue
+++ b/Display_Config/Display_Config/src/components/RenderOptions.vue
@@ -3,24 +3,29 @@
     <v-card-title>Graphics Options</v-card-title>
     <v-card-text class="pb-2">
       <div class="d-flex ga-2 flex-column">
-        <v-select
-          v-model="renderSettings.renderer"
-          label="Renderer"
-          :items="renderDevices"
-        />
-        <v-select
-          v-model="renderSettings.cardId"
-          label="Card ID"
-          :disabled="formIsLoading || getCardIds(renderSettings.renderer).isLoading"
-          :items="getCardIds(renderSettings.renderer).value"
-        />
+        <div class="d-flex ga-2">
+          <v-select
+            v-model="renderSettings.renderer"
+            label="Renderer"
+            style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;"
+            :items="renderDevices"
+          />
+          <v-select
+            v-model="renderSettings.cardId"
+            label="Card ID"
+            :disabled="formIsLoading || getCardIds(renderSettings.renderer).isLoading"
+            :items="getCardIds(renderSettings.renderer).value"
+          />
+
+        </div>
         <div class="d-flex ga-2">
           <v-combobox
             v-model="renderSettings.resolution"
-            style="min-width: 60%"
+            style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;"
             label="Resolution"
             :disabled="formIsLoading || getResolutions(renderSettings.renderer).isLoading"
             :items="getResolutions(renderSettings.renderer).value"
+            :rules="[(v: string) => validateResolution(v)]"
           />
           <v-select
             v-model="renderSettings.colourDepth"
@@ -28,8 +33,19 @@
             :items="colorDepths"
           />
         </div>
-        <v-checkbox v-model="renderSettings.fullscreen" label="Full screen"></v-checkbox>
         <LanguageSelect />
+        <RenderDistanceRow :formIsLoading="formIsLoading" />
+        <div class="d-flex ga-2">
+          <v-select
+            label="Ground Detail"
+            :items="groundDetailOptions"
+            item-title="text"
+            item-value="value"
+            style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;"
+            v-model="renderSettings.groundDetail"
+          />
+          <v-checkbox v-model="renderSettings.fullscreen" label="Full screen"></v-checkbox>
+        </div>
       </div>
     </v-card-text>
   </v-card>
@@ -43,7 +59,6 @@ import {
   fetchCardIds,
 } from "../services/resolutionAndCardIdFetcher";
 
-// fixme: it should just use v-form disabled...
 const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
 const { renderSettings } = useRenderSettingsStore();
 
@@ -61,6 +76,13 @@ function getResolutions(renderer?: string) {
   return resolutionData[renderer];
 }
 
+const groundDetailOptions = [
+  { text: '1 (Very Low)', value: 1 },
+  { text: '2 (Low)', value: 2 },
+  { text: '3 (Normal)', value: 3 },
+  { text: '4 (Maximum)', value: 4 }
+];
+
 const cardIdData: Record<string, SyncPromise<string[]>> = {};
 function getCardIds(renderer?: string) {
   if (!renderer) {
@@ -71,4 +93,17 @@ function getCardIds(renderer?: string) {
   }
   return cardIdData[renderer];
 }
+
+function validateResolution(resolution: string | undefined) {
+  if (!resolution) {
+    return 'required';
+  }
+  const spl = resolution.split("x");
+  if (spl.length !== 2) {
+    return 'invalid format';
+  }
+  const [width, height] = resolution.split("x").map(Number);
+  return !isNaN(width) && !isNaN(height) && width > 0 && height > 0;
+}
+
 </script>

--- a/Display_Config/Display_Config/src/components/RenderOptions.vue
+++ b/Display_Config/Display_Config/src/components/RenderOptions.vue
@@ -33,7 +33,10 @@
             :items="colorDepths"
           />
         </div>
-        <LanguageSelect />
+        <div class="d-flex ga-2">
+          <LanguageSelect style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;" />
+          <v-checkbox v-model="renderSettings.fullscreen" label="Full screen"></v-checkbox>
+        </div>
         <RenderDistanceRow :formIsLoading="formIsLoading" />
         <div class="d-flex ga-2">
           <v-select
@@ -44,7 +47,11 @@
             style="flex-basis: 60%; flex-shrink: 0; flex-grow: 0;"
             v-model="renderSettings.groundDetail"
           />
-          <v-checkbox v-model="renderSettings.fullscreen" label="Full screen"></v-checkbox>
+          <v-select
+            v-model="renderSettings.ghostPlayer"
+            label="Ghost Player"
+            :items="ghostPlayers"
+          />
         </div>
       </div>
     </v-card-text>
@@ -62,6 +69,7 @@ import {
 const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
 const { renderSettings } = useRenderSettingsStore();
 
+const ghostPlayers = ["Vincent", "Keith", "Ulrika", "Akiko", "Guide", "Mike"];
 const renderDevices = ["DirectX6", "DirectX7", "OpenGL", "Software2"];
 const colorDepths = ["16bit", "32bit"];
 

--- a/Display_Config/Display_Config/src/components/TrainerOptions.vue
+++ b/Display_Config/Display_Config/src/components/TrainerOptions.vue
@@ -29,6 +29,5 @@ import EnableLoggingTooltip from "./EnableLoggingTooltip.vue";
 import FovSelectorRow from "./FovSelectorRow.vue";
 const { trainerSettings } = useTrainerUISettingsStore();
 
-// fixme: it should just use v-form disabled...
 const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
 </script>

--- a/Display_Config/Display_Config/src/components/TrainerOptions.vue
+++ b/Display_Config/Display_Config/src/components/TrainerOptions.vue
@@ -15,10 +15,13 @@
         v-model="trainerSettings.makeGhostsOpaque"
         label="Make replay ghosts opaque"
       />
-      <v-checkbox
-        v-model="trainerSettings.matchGhostSoundsToCharacter"
-        label="Match ghost sounds to character"
-      />
+      <div class="d-flex ga-2" style="align-items: center">
+        <v-checkbox
+          v-model="trainerSettings.matchGhostSoundsToCharacter"
+          label="Match ghost sounds to character"
+        />
+        <GhostSoundsTooltip />
+      </div>
     </v-card-text>
   </v-card>
 </template>
@@ -27,6 +30,7 @@
 import { useTrainerUISettingsStore } from "@/stores/trainerSettings";
 import EnableLoggingTooltip from "./EnableLoggingTooltip.vue";
 import FovSelectorRow from "./FovSelectorRow.vue";
+import GhostSoundsTooltip from "./GhostSoundsTooltip.vue";
 const { trainerSettings } = useTrainerUISettingsStore();
 
 const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();

--- a/Display_Config/Display_Config/src/components/TrainerOptions.vue
+++ b/Display_Config/Display_Config/src/components/TrainerOptions.vue
@@ -3,64 +3,32 @@
     <v-card-title>Trainer Options</v-card-title>
     <v-card-text class="pb-2">
       <v-checkbox v-model="trainerSettings.use4xFonts" label="Use 4x Fonts" />
-      <div class="d-flex align-items-center ga-2">
-        <v-checkbox
-          class="align-self-center flex-grow"
-          v-model="trainerSettings.changeFov"
-          label="Change FOV"
-          style="min-width: 120px"
-        />
-        <v-text-field
-          class="fovWidth"
-          type="number"
-          v-model="trainerSettings.fovWidth"
-          :disabled="formIsLoading || !trainerSettings.changeFov"
-          hide-spin-buttons
-          label="Width"
-        />
-        <v-text-field
-          class="fovHeight"
-          type="number"
-          v-model="trainerSettings.fovHeight"
-          :disabled="formIsLoading || !trainerSettings.changeFov"
-          hide-spin-buttons
-          label="Height"
-        />
-        <p class="align-self-center">{{ getFovFactor() }}</p>
-      </div>
+      <FovSelectorRow :formIsLoading="formIsLoading" />
       <div class="d-flex ga-2" style="align-items: center">
-        <v-checkbox v-model="trainerSettings.enableLogging" label="Enable Logging" />
+        <v-checkbox
+          v-model="trainerSettings.enableLogging"
+          label="Enable Logging"
+        />
         <EnableLoggingTooltip />
       </div>
-      <v-checkbox v-model="trainerSettings.makeGhostsOpaque" label="Make replay ghosts opaque" />
+      <v-checkbox
+        v-model="trainerSettings.makeGhostsOpaque"
+        label="Make replay ghosts opaque"
+      />
+      <v-checkbox
+        v-model="trainerSettings.matchGhostSoundsToCharacter"
+        label="Match ghost sounds to character"
+      />
     </v-card-text>
   </v-card>
 </template>
 
 <script setup lang="ts">
-import { useTrainerSettingsStore } from "@/stores/trainerSettings";
+import { useTrainerUISettingsStore } from "@/stores/trainerSettings";
 import EnableLoggingTooltip from "./EnableLoggingTooltip.vue";
-const { trainerSettings } = useTrainerSettingsStore();
+import FovSelectorRow from "./FovSelectorRow.vue";
+const { trainerSettings } = useTrainerUISettingsStore();
 
 // fixme: it should just use v-form disabled...
 const { formIsLoading } = defineProps<{ formIsLoading: boolean }>();
-
-function getFovFactor() {
-  if (!trainerSettings.fovWidth || !trainerSettings.fovHeight) {
-    return "";
-  }
-  return (
-    trainerSettings.fovWidth /
-    trainerSettings.fovHeight /
-    (4 / 3)
-  ).toFixed(2);
-}
-
 </script>
-
-<style scoped>
-.fovWidth,
-.fovHeight {
-  max-width: 5em;
-}
-</style>

--- a/Display_Config/Display_Config/src/pages/HomePage.vue
+++ b/Display_Config/Display_Config/src/pages/HomePage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container style="max-width: 400px">
-    <v-form :disabled="playLoading">
+    <v-form ref="form" :disabled="playLoading">
       <RenderOptions :formIsLoading="playLoading" />
       <TrainerOptions :formIsLoading="playLoading" class="mt-2" />
       <Autostart @auto-play="handleAutoplay()" />
@@ -13,19 +13,25 @@
   </v-container>
 </template>
 
+<style>
+.v-field {
+  --v-field-padding-start: 12px;
+  --v-field-padding-end: 12px;
+}
+.v-field.v-field--appended {
+  --v-field-padding-end: 0px;
+}
+</style>
+
 <script lang="ts" setup>
 import { invoke } from '@tauri-apps/api/core';
 import { ref } from 'vue';
-import { getCurrentWindow } from '@tauri-apps/api/window';
-import { getAsRdConfig, useRenderSettingsStore } from '@/stores/renderSettings';
+import { handlePlayAsync } from '../services/handlePlay';
 import Autostart from '@/components/Autostart.vue';
-import { useTrainerSettingsStore } from '@/stores/trainerSettings';
-import { exit } from '@tauri-apps/plugin-process';
-import { useErrorStore } from '@/stores/errorStore';
+import { VForm } from 'vuetify/components';
 
 const playLoading = ref(false);
-const errorStore = useErrorStore();
-
+const form = ref<VForm | undefined>();
 async function handleAutoplay() {
   if (!playLoading.value) {
     await handlePlay();
@@ -33,36 +39,10 @@ async function handleAutoplay() {
 }
 
 async function handlePlay() {
-  console.log(useRenderSettingsStore().renderSettings);
-  playLoading.value = true;
-  try {
-    console.log (await invoke('read_rd_config'));
-    console.log(await invoke('write_rd_config', { config: getAsRdConfig() }));
-    console.log(await invoke('write_language', { language: useRenderSettingsStore().renderSettings.language }));
-    const { trainerSettings } = useTrainerSettingsStore();
-    if (trainerSettings.changeFov || trainerSettings.use4xFonts || trainerSettings.enableLogging || trainerSettings.makeGhostsOpaque) {
-      if (typeof trainerSettings.fovHeight === 'string') trainerSettings.fovHeight = parseInt(trainerSettings.fovHeight);
-      if (typeof trainerSettings.fovWidth === 'string') trainerSettings.fovWidth = parseInt(trainerSettings.fovWidth);
-      const r2 = await invoke('run_inject', { trainerSettings });
-      console.log(r2);
-    }
-    playLoading.value = false;
-    await getCurrentWindow().setFocus();
-    await exit(0);
-  } catch (e) {
-    if (e instanceof Error || typeof e === 'string') {
-      const errorString = e instanceof Error ? e.message : e;
-      if (errorString.startsWith(`Timeout waiting for 'Finished.' in log`)) {
-        const logData = await invoke<string[]>('get_log_data');
-        errorStore.setError(e, {logData});
-      } else {
-        errorStore.setError(e);
-      }
-    } else {
-      alert(e);
-    }
-    playLoading.value = false;
-  }
+  const { valid } = await form.value!.validate();
+  if (!valid) return;
+  // playLoading.value = true; await sleep(3000); playLoading.value = false; return;
+  await handlePlayAsync(playLoading);
 }
 
 async function handleExit() {

--- a/Display_Config/Display_Config/src/pages/HomePage.vue
+++ b/Display_Config/Display_Config/src/pages/HomePage.vue
@@ -29,6 +29,7 @@ import { ref } from 'vue';
 import { handlePlayAsync } from '../services/handlePlay';
 import Autostart from '@/components/Autostart.vue';
 import { VForm } from 'vuetify/components';
+import { loadFromFiles, setupFileSync } from '../services/fileSyncService';
 
 const playLoading = ref(false);
 const form = ref<VForm | undefined>();
@@ -37,11 +38,12 @@ async function handleAutoplay() {
     await handlePlay();
   }
 }
+loadFromFiles();
+setupFileSync(form);
 
 async function handlePlay() {
   const { valid } = await form.value!.validate();
   if (!valid) return;
-  // playLoading.value = true; await sleep(3000); playLoading.value = false; return;
   await handlePlayAsync(playLoading);
 }
 

--- a/Display_Config/Display_Config/src/plugins/vuetify.ts
+++ b/Display_Config/Display_Config/src/plugins/vuetify.ts
@@ -36,6 +36,8 @@ export default createVuetify({
     },
     VTextField: {
       hideDetails: true,
+      hideSpinButtons: true,
+      persistentPlaceholder: true,
     }
   }
 })

--- a/Display_Config/Display_Config/src/services/fileSyncService.ts
+++ b/Display_Config/Display_Config/src/services/fileSyncService.ts
@@ -1,0 +1,31 @@
+import { useRenderSettingsStore } from "@/stores/renderSettings";
+import { invoke } from "@tauri-apps/api/core";
+import { tryParseInt } from "./stringUtil";
+import type { VForm } from "vuetify/components";
+import type { Ref } from "vue";
+import { writeDetailConfig } from "./handlePlay";
+
+
+export async function loadFromFiles() {
+  const { renderSettings } = useRenderSettingsStore();
+
+  const rows = await invoke<Array<[string, string]>>('read_detail_config') ?? [];
+  for (const [key, v] of rows) {
+    if (key === 'visibility_cube_width' && tryParseInt(v)) {
+      renderSettings.renderDistance = parseInt(v);
+    }
+    else if (key === 'ground_detail' && tryParseInt(v)) {
+      renderSettings.groundDetail = parseInt(v);
+    }
+  }
+}
+
+export async function setupFileSync(form: Ref<VForm | undefined>) {
+  const renderSettingsStore  = useRenderSettingsStore();
+  renderSettingsStore.$subscribe(async () => {
+    const { valid } = await form.value!.validate();
+    if (!valid) return;
+
+    await writeDetailConfig();
+  });
+}

--- a/Display_Config/Display_Config/src/services/fileSyncService.ts
+++ b/Display_Config/Display_Config/src/services/fileSyncService.ts
@@ -2,7 +2,7 @@ import { useRenderSettingsStore } from "@/stores/renderSettings";
 import { invoke } from "@tauri-apps/api/core";
 import { tryParseInt } from "./stringUtil";
 import type { VForm } from "vuetify/components";
-import type { Ref } from "vue";
+import { render, type Ref } from "vue";
 import { writeDetailConfig } from "./handlePlay";
 
 
@@ -18,6 +18,14 @@ export async function loadFromFiles() {
       renderSettings.groundDetail = parseInt(v);
     }
   }
+
+  try {
+    const playerType = await invoke<string>('get_first_player_type');
+    renderSettings.ghostPlayer = playerType.charAt(0).toUpperCase() + playerType.slice(1);;
+
+  } catch (e) {
+    console.log(e);
+  }
 }
 
 export async function setupFileSync(form: Ref<VForm | undefined>) {
@@ -27,5 +35,6 @@ export async function setupFileSync(form: Ref<VForm | undefined>) {
     if (!valid) return;
 
     await writeDetailConfig();
+    await invoke('set_first_player_type', { character: renderSettingsStore.renderSettings.ghostPlayer });
   });
 }

--- a/Display_Config/Display_Config/src/services/fileSyncService.ts
+++ b/Display_Config/Display_Config/src/services/fileSyncService.ts
@@ -2,7 +2,7 @@ import { useRenderSettingsStore } from "@/stores/renderSettings";
 import { invoke } from "@tauri-apps/api/core";
 import { tryParseInt } from "./stringUtil";
 import type { VForm } from "vuetify/components";
-import { render, type Ref } from "vue";
+import { type Ref } from "vue";
 import { writeDetailConfig } from "./handlePlay";
 
 

--- a/Display_Config/Display_Config/src/services/fovOptions.ts
+++ b/Display_Config/Display_Config/src/services/fovOptions.ts
@@ -1,0 +1,1 @@
+export type FovType = "MatchRes" | "Original" | "Custom";

--- a/Display_Config/Display_Config/src/services/handlePlay.ts
+++ b/Display_Config/Display_Config/src/services/handlePlay.ts
@@ -15,7 +15,7 @@ export async function handlePlayAsync(playLoading: Ref<boolean>) {
   playLoading.value = true;
   try {
     console.log(await invoke('read_rd_config'));
-    console.log(await invoke('write_detail_config', { detailConfig: getAsDetailConfig() }));
+    console.log(await writeDetailConfig());
     console.log(await invoke('write_rd_config', { rdConfig: getAsRdConfig() }));
     console.log(await invoke('write_language', { language: useRenderSettingsStore().renderSettings.language }));
     const trainerSettings = getTrainerSettings();
@@ -40,6 +40,10 @@ export async function handlePlayAsync(playLoading: Ref<boolean>) {
     }
     playLoading.value = false;
   }
+}
+
+export async function writeDetailConfig() {
+  return await invoke('write_detail_config', { detailConfig: getAsDetailConfig() })
 }
 
 function requiresInject(trainerSettings: TrainerSettings): boolean {

--- a/Display_Config/Display_Config/src/services/handlePlay.ts
+++ b/Display_Config/Display_Config/src/services/handlePlay.ts
@@ -1,0 +1,90 @@
+
+import { useTrainerUISettingsStore } from '../stores/trainerSettings';
+import { exit } from '@tauri-apps/plugin-process';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { getAsRdConfig, useRenderSettingsStore } from '../stores/renderSettings';
+import { invoke } from '@tauri-apps/api/core';
+import type { Ref } from 'vue';
+import { useErrorStore } from '@/stores/errorStore';
+import type { TrainerUISettings } from './types';
+
+
+export async function handlePlayAsync(playLoading: Ref<boolean>) {
+  const errorStore = useErrorStore();
+  console.log(useRenderSettingsStore().renderSettings);
+  playLoading.value = true;
+  try {
+    console.log (await invoke('read_rd_config'));
+    console.log(await invoke('write_rd_config', { config: getAsRdConfig() }));
+    console.log(await invoke('write_language', { language: useRenderSettingsStore().renderSettings.language }));
+    const trainerJsonSettings = getTrainerSEttings();
+    if (requiresInject(trainerJsonSettings)) {
+
+      const r2 = await invoke('run_inject', { trainerSettings: trainerJsonSettings });
+      console.log(r2);
+    }
+    playLoading.value = false;
+    await getCurrentWindow().setFocus();
+    await exit(0);
+  } catch (e) {
+    if (e instanceof Error || typeof e === 'string') {
+      const errorString = e instanceof Error ? e.message : e;
+      if (errorString.startsWith(`Timeout waiting for 'Finished.' in log`)) {
+        const logData = await invoke<string[]>('get_log_data');
+        errorStore.setError(e, {logData});
+      } else {
+        errorStore.setError(e);
+      }
+    } else {
+      alert(e);
+    }
+    playLoading.value = false;
+  }
+}
+
+function requiresInject(trainerSettings: TrainerSettings): boolean {
+  return trainerSettings.changeFov || trainerSettings.use4xFonts || trainerSettings.enableLogging || trainerSettings.makeGhostsOpaque || trainerSettings.matchGhostSoundsToCharacter;
+}
+
+function getTrainerSEttings(): TrainerSettings {
+  const { trainerSettings } = useTrainerUISettingsStore();
+  const changeFov = shouldChangeFov(trainerSettings);
+
+  return {
+    use4xFonts: trainerSettings.use4xFonts,
+    changeFov,
+    fovWidth: tryParseInt(trainerSettings.fovWidth),
+    fovHeight: tryParseInt(trainerSettings.fovHeight),
+    enableLogging: trainerSettings.enableLogging,
+    makeGhostsOpaque: trainerSettings.makeGhostsOpaque,
+    matchGhostSoundsToCharacter: trainerSettings.matchGhostSoundsToCharacter,
+  };
+}
+
+function shouldChangeFov(trainerSettings: TrainerUISettings): boolean {
+  if (trainerSettings.fovType === "Original") return false;
+
+  const fovWidth = tryParseInt(trainerSettings.fovWidth);
+  const fovHeight = tryParseInt(trainerSettings.fovHeight);
+  if (!fovWidth || !fovHeight) return false;
+
+  // 4/3 = width/height
+  if (4 * fovHeight === 3 * fovWidth) return false;
+  return true;
+}
+
+function tryParseInt(value: string | number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsedValue = parseInt((value as unknown as string) ?? '');
+  return isNaN(parsedValue) ? undefined : parsedValue;
+}
+
+interface TrainerSettings {
+  use4xFonts: boolean;
+  changeFov: boolean;
+  fovWidth?: number;
+  fovHeight?: number;
+  enableLogging: boolean;
+  makeGhostsOpaque: boolean;
+  matchGhostSoundsToCharacter: boolean;
+}

--- a/Display_Config/Display_Config/src/services/stringUtil.ts
+++ b/Display_Config/Display_Config/src/services/stringUtil.ts
@@ -1,0 +1,6 @@
+
+export function tryParseInt(value: string | number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsedValue = parseInt((value as unknown as string) ?? '');
+  return isNaN(parsedValue) ? undefined : parsedValue;
+}

--- a/Display_Config/Display_Config/src/services/types.ts
+++ b/Display_Config/Display_Config/src/services/types.ts
@@ -14,6 +14,7 @@ export interface RenderSettings {
   language: string;
   renderDistance: number;
   groundDetail: number;
+  ghostPlayer: string;
 }
 
 export interface TrainerUISettings {

--- a/Display_Config/Display_Config/src/services/types.ts
+++ b/Display_Config/Display_Config/src/services/types.ts
@@ -1,6 +1,8 @@
+import type { FovType } from "./fovOptions";
+
 export interface Config {
   renderSettings: RenderSettings;
-  trainerSettings: TrainerSettings;
+  trainerUISettings: TrainerUISettings;
 }
 
 export interface RenderSettings {
@@ -10,13 +12,16 @@ export interface RenderSettings {
   colourDepth?: string;
   fullscreen: boolean;
   language: string;
+  renderDistance: number;
+  groundDetail: number;
 }
 
-export interface TrainerSettings {
+export interface TrainerUISettings {
   use4xFonts: boolean;
-  changeFov: boolean;
+  fovType: FovType;
   fovWidth?: number;
   fovHeight?: number;
   enableLogging: boolean;
   makeGhostsOpaque: boolean;
+  matchGhostSoundsToCharacter: boolean;
 }

--- a/Display_Config/Display_Config/src/stores/renderSettings.ts
+++ b/Display_Config/Display_Config/src/stores/renderSettings.ts
@@ -17,6 +17,8 @@ function getDefaultRenderSettings(): { renderSettings: Ref<RenderSettings> } {
     colourDepth: "32bit",
     fullscreen: false,
     language: "English",
+    renderDistance: 450,
+    groundDetail: 3,
   });
   return { renderSettings: settings };
 }

--- a/Display_Config/Display_Config/src/stores/renderSettings.ts
+++ b/Display_Config/Display_Config/src/stores/renderSettings.ts
@@ -22,6 +22,7 @@ function getDefaultRenderSettings(): { renderSettings: Ref<RenderSettings> } {
     language: "English",
     renderDistance: 450,
     groundDetail: 3,
+    ghostPlayer: "Vincent"
   });
   return { renderSettings: settings };
 }

--- a/Display_Config/Display_Config/src/stores/renderSettings.ts
+++ b/Display_Config/Display_Config/src/stores/renderSettings.ts
@@ -2,6 +2,9 @@ import { defineStore } from 'pinia';
 import { ref, type Ref } from 'vue';
 import type { RenderSettings } from '../services/types';
 import { getPersistentSettings } from './persistentStoreHelper';
+import type { DetailConfig, RdConfig } from './types';
+import { tryParseInt } from '@/services/stringUtil';
+
 
 export const useRenderSettingsStore = defineStore(
   'renderSettings',
@@ -23,15 +26,6 @@ function getDefaultRenderSettings(): { renderSettings: Ref<RenderSettings> } {
   return { renderSettings: settings };
 }
 
-interface RdConfig {
-  apiName: string;
-  width: number;
-  height: number;
-  depth: number;
-  cardId: number;
-  fullscreen: boolean;
-}
-
 export function getAsRdConfig(): RdConfig {
   const { renderSettings } = useRenderSettingsStore();
   return {
@@ -41,5 +35,13 @@ export function getAsRdConfig(): RdConfig {
     depth: parseInt(renderSettings.colourDepth!.split('bit')[0]),
     cardId: renderSettings.cardId!,
     fullscreen: renderSettings.fullscreen,
+  }
+}
+
+export function getAsDetailConfig(): DetailConfig {
+  const { renderSettings } = useRenderSettingsStore();
+  return {
+    renderDistance: tryParseInt(renderSettings.renderDistance),
+    groundDetail: tryParseInt(renderSettings.groundDetail),
   }
 }

--- a/Display_Config/Display_Config/src/stores/trainerSettings.ts
+++ b/Display_Config/Display_Config/src/stores/trainerSettings.ts
@@ -1,22 +1,23 @@
 import { defineStore } from "pinia";
 import { ref, type Ref } from "vue";
-import type { TrainerSettings } from "../services/types";
+import type { TrainerUISettings } from "../services/types";
 import { getPersistentSettings } from './persistentStoreHelper';
 
-export const useTrainerSettingsStore = defineStore(
+export const useTrainerUISettingsStore = defineStore(
   "trainerForm",
-  getDefaultTrainerSettings,
-  getPersistentSettings(getDefaultTrainerSettings)
+  getDefaultTrainerUISettings,
+  getPersistentSettings(getDefaultTrainerUISettings)
 );
 
-function getDefaultTrainerSettings(): { trainerSettings: Ref<TrainerSettings> } {
-  const settings = ref<TrainerSettings>({
-    changeFov: false,
+function getDefaultTrainerUISettings(): { trainerSettings: Ref<TrainerUISettings> } {
+  const settings = ref<TrainerUISettings>({
+    fovType: "MatchRes",
     use4xFonts: false,
     fovWidth: 1920,
     fovHeight: 1080,
     enableLogging: false,
     makeGhostsOpaque: false,
+    matchGhostSoundsToCharacter: false,
   });
   return { trainerSettings: settings };
 }

--- a/Display_Config/Display_Config/src/stores/types.ts
+++ b/Display_Config/Display_Config/src/stores/types.ts
@@ -1,0 +1,13 @@
+export interface RdConfig {
+  apiName: string;
+  width: number;
+  height: number;
+  depth: number;
+  cardId: number;
+  fullscreen: boolean;
+}
+
+export interface DetailConfig {
+  renderDistance: number | undefined;
+  groundDetail: number | undefined;
+}

--- a/Display_Config/Display_Config_Resources/Display_Config_Helper/Display_Config_Helper.vcxproj
+++ b/Display_Config/Display_Config_Resources/Display_Config_Helper/Display_Config_Helper.vcxproj
@@ -15,6 +15,7 @@
     <ClInclude Include="src\external\safetyhook.hpp" />
     <ClInclude Include="src\external\Zydis.h" />
     <ClInclude Include="src\fixes.hpp" />
+    <ClInclude Include="src\fixGhostSounds.hpp" />
     <ClInclude Include="src\helper.hpp" />
     <ClInclude Include="src\log.hpp" />
     <ClInclude Include="src\PathUtil.hpp" />

--- a/Display_Config/Display_Config_Resources/Display_Config_Helper/Display_Config_Helper.vcxproj.filters
+++ b/Display_Config/Display_Config_Resources/Display_Config_Helper/Display_Config_Helper.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="src\PathUtil.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\fixGhostSounds.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\main.cc">

--- a/Display_Config/Display_Config_Resources/Display_Config_Helper/src/fixes.hpp
+++ b/Display_Config/Display_Config_Resources/Display_Config_Helper/src/fixes.hpp
@@ -102,3 +102,4 @@ void EnableLogging() {
         Log("EnableLogging: Failed to find Toggle_Logging function");
     }
 }
+

--- a/Display_Config/Display_Config_Resources/Display_Config_Helper/src/helper.hpp
+++ b/Display_Config/Display_Config_Resources/Display_Config_Helper/src/helper.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "stdafx.h"
 
 namespace Memory

--- a/Display_Config/Display_Config_Resources/Display_Config_Helper/src/main.cc
+++ b/Display_Config/Display_Config_Resources/Display_Config_Helper/src/main.cc
@@ -1,6 +1,7 @@
 #include <windows.h>
 #include "log.hpp"
 #include "fixes.hpp"
+#include "matchGhostSoundsToCharacter.hpp"
 #include "external/json.hpp"
 #include "PathUtil.hpp"
 #include <fstream>
@@ -39,6 +40,11 @@ void run() {
         Log("Make ghosts opaque");
         DoMakeGhostsOpaque();
     }
+
+    if (data.value("matchGhostSoundsToCharacter", false)) {
+        Log("Match ghost sounds to character");
+        DoMatchGhostSoundsToCharacter();
+	}
 }
 
 BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID) {

--- a/Display_Config/Display_Config_Resources/Display_Config_Helper/src/matchGhostSoundsToCharacter.hpp
+++ b/Display_Config/Display_Config_Resources/Display_Config_Helper/src/matchGhostSoundsToCharacter.hpp
@@ -1,0 +1,52 @@
+#include <windows.h>
+#include "external/safetyhook.hpp"
+#include "helper.hpp"
+#include "Log.hpp"
+#include <string>
+#include <regex>
+
+#pragma once
+
+void DoMatchGhostSoundsToCharacter() {
+    const auto module = GetModuleHandleA("Supreme_Game.dll");
+    if (!module) {
+        Log("DoMatchGhostSoundsToCharacter: Failed to find Supreme_Game.dll");
+        return;
+    }
+
+    std::uint8_t* setPlayerNameAddress = Memory::PatternScan(module, "8B CE E8 1F 5F FF FF 8B CE E8 D8 59 FF FF 8B 4C 24 10");
+    if (!setPlayerNameAddress) {
+        Log("DoMatchGhostSoundsToCharacter: Couldn't find setPlayerNameAddress");
+        return;
+    }
+
+    Log(std::format("DoMatchGhostSoundsToCharacter: Address is Supreme_Game.dll+{:x}", setPlayerNameAddress - (std::uint8_t*)module));
+
+    static safetyhook::MidHook setNameHook{};
+    setNameHook = safetyhook::create_mid(setPlayerNameAddress, [](safetyhook::Context& ctx) {
+        static std::unordered_map<std::string, std::string> characterNames;
+        char* playerMeshConfig = *reinterpret_cast<char**>(ctx.esi + 0x64); // example "data/characters/vincent/plrmshcnf.txt"
+        if (!playerMeshConfig) {
+            Log("DoMatchGhostSoundsToCharacter: ERROR: playerMeshConfig is null");
+            return;
+        }
+
+        std::string configPath(playerMeshConfig);
+        std::regex pattern(R"(data/characters/([^/]+)/plrmshcnf\.txt)");
+        std::smatch matches;
+
+        if (std::regex_match(configPath, matches, pattern) && matches.size() > 1) {
+            std::string characterKey = matches[1].str();
+
+            if (!characterNames.contains(characterKey)) {
+                characterNames[characterKey] = characterKey;
+            }
+            *reinterpret_cast<const char**>(ctx.esp) = characterNames[characterKey].c_str();
+        }
+        else {
+            Log("DoMatchGhostSoundsToCharacter: ERROR: regex match failed for " + std::string(playerMeshConfig ? playerMeshConfig : "null"));
+        }
+    });
+    Log("DoMatchGhostSoundsToCharacter: Fix applied");
+}
+

--- a/Display_Config/README.md
+++ b/Display_Config/README.md
@@ -9,12 +9,13 @@ Example `Display_Config_Helper.json`:
   "fovWidth": 1920,
   "fovHeight": 1080,
   "enableLogging": true,
-  "makeGhostsOpaque": true
+  "makeGhostsOpaque": true,
+  "matchGhostSoundsToCharacter": true
 }
 ```
 
 Notes:
-* `use4xFonts` currently requires changing the font sprites yourself 
+* `use4xFonts` currently requires changing the font textures yourself 
 
 ## Building
 

--- a/ss-dat-info.code-workspace
+++ b/ss-dat-info.code-workspace
@@ -11,6 +11,11 @@
     }
   ],
   "settings": {
+    "editor.tabSize": 2,
+    "[rust]": {
+      "editor.tabSize": 4,
+      "editor.defaultFormatter": "rust-lang.rust-analyzer"
+    },
     "[typescript]": {
       "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     },

--- a/ss-dat-info.code-workspace
+++ b/ss-dat-info.code-workspace
@@ -1,0 +1,30 @@
+{
+  "folders": [
+    {
+      "path": "analyze"
+    },
+    {
+      "path": "threejs"
+    },
+    {
+      "path": "Display_Config/Display_Config"
+    }
+  ],
+  "settings": {
+    "[typescript]": {
+      "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[vue]": {
+      "editor.defaultFormatter": "Vue.volar"
+    },
+    "eslint.format.enable": true,
+  },
+  "extensions": {
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "Vue.volar",
+      "tauri-apps.tauri-vscode",
+      "rust-lang.rust-analyzer"
+    ]
+  }
+}


### PR DESCRIPTION
The default replay ghosts use the sounds of mike. The `Match ghost sounds to character` checkbox fixes this.

* Ghost Player uses sounds of first mesh_config_file in `data\characters\player_types.txt` (`data\characters\vincent\plrmshcnf.txt` would be `data\characters\vincent\speech_cfg.txt`)
*  Guide Player always uses sounds of `data\characters\guide\speech_cfg.txt`

## Other changes
* Add render distance, ground detail and ghost type options 
* Use "FOV Option" as "MatchRes" by default. It is a better default for widescreen to use the fixed FOV.